### PR TITLE
Decoding XML lists

### DIFF
--- a/src/AirQual.elm
+++ b/src/AirQual.elm
@@ -34,3 +34,8 @@ oneLineDecoder =
 measurementDecoder : Decoder (List Measurement)
 measurementDecoder =
     path [ "category", "region", "station", "measurement" ] (list oneLineDecoder)
+
+
+measurementSingleDecoder : Decoder Measurement
+measurementSingleDecoder =
+    path [ "category", "region", "station", "measurement" ] (single oneLineDecoder)

--- a/src/AirQual.elm
+++ b/src/AirQual.elm
@@ -27,10 +27,10 @@ type alias Measurement =
 oneLineDecoder : Decoder Measurement
 oneLineDecoder =
     map2 Measurement
-        (path [ "measurement" ] (single <| stringAttr "rating_name"))
-        (path [ "measurement" ] (single float))
+        (stringAttr "rating_name")
+        float
 
 
 measurementDecoder : Decoder (List Measurement)
 measurementDecoder =
-    path [ "category", "region", "station" ] (list oneLineDecoder)
+    path [ "category", "region", "station", "measurement" ] (list oneLineDecoder)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,7 +10,44 @@ import Xml.Decode exposing (..)
 suite : Test
 suite =
     describe "Basic XML decode"
-        [ test "Measurement node decode" <|
+        [ test "Measurement single item decode" <|
+            \_ ->
+                """
+                <airdata provider="Department of Environment and Science" state="Queensland" country="Australia">
+                    <category name="Air Quality" measurementhour="13" measurementdate="2021-07-15">
+                        <region name="Central Queensland" information="https://www.qld.gov.au/environment/pollution/monitoring/air/air-monitoring/network-stations/central-qld">
+                            <station name="Moranbah (Utah Dr)" information="https://apps.des.qld.gov.au/air-quality/stations/?station=mor" longitude="148.071" latitude="-21.9995">
+                                <measurement name="Particle PM10" rating_name="Very Good" rating="1" index="30">15</measurement>
+                            </station>
+                        </region>
+                    </category>
+                </airdata>
+                """
+                    |> decodeString measurementSingleDecoder
+                    |> Expect.equal
+                        (Ok
+                            { rating_name = "Very Good", measurement = 15 }
+                        )
+        , test "Measurement single list decode" <|
+            \_ ->
+                """
+                <airdata provider="Department of Environment and Science" state="Queensland" country="Australia">
+                    <category name="Air Quality" measurementhour="13" measurementdate="2021-07-15">
+                        <region name="Central Queensland" information="https://www.qld.gov.au/environment/pollution/monitoring/air/air-monitoring/network-stations/central-qld">
+                            <station name="Moranbah (Utah Dr)" information="https://apps.des.qld.gov.au/air-quality/stations/?station=mor" longitude="148.071" latitude="-21.9995">
+                                <measurement name="Particle PM10" rating_name="Very Good" rating="1" index="30">15</measurement>
+                            </station>
+                        </region>
+                    </category>
+                </airdata>
+                """
+                    |> decodeString measurementDecoder
+                    |> Expect.equal
+                        (Ok
+                            [ { rating_name = "Very Good", measurement = 15 }
+                            ]
+                        )
+        , test "Measurement multi list decode" <|
             \_ ->
                 """
                 <airdata provider="Department of Environment and Science" state="Queensland" country="Australia">


### PR DESCRIPTION
That was a good puzzle! What you wrote made sense to me, but then I noticed from the docs that the path to the node in the top-level decoder _includes_ the repeated node (`<measurement>` in this case). The one-line measurement decoder itself doesn't actually know which node it's a part of, only what it's expected to contain. That seems a bit odd, but it's in line with how JSON decoders work I think (they don't know what key that are associated with, at least the way I've used them).

As the [docs note](https://package.elm-lang.org/packages/ymtszw/elm-xml-decode/latest/Xml-Decode#path), XML doesn't have an explicit way to indicate whether you're dealing with a list of values or a single instance, so I guess it makes sense to always deal with lists of nodes, even if it's a list of one, unless you know for sure you'll only have a single instance of a node.

(Also, this is my first ever pull request! How did I do?)
